### PR TITLE
[Security] Bump CI actions and add permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,7 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.23', '1.24']
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -39,7 +36,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ matrix.go-version }}
+        cache: true
+        go-version-file: go.mod
 
     - name: Download dependencies
       run: make modules
@@ -58,7 +56,7 @@ jobs:
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-reports-go-${{ matrix.go-version }}
+        name: coverage-reports-go
         path: |
           coverage.out
           coverage.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -31,10 +34,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -48,9 +51,9 @@ jobs:
       run: make test-coverage
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
       with:
-        version: v2.2.0
+        version: v2.7.2
 
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
@@ -72,12 +75,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        cache: true
+        go-version-file: go.mod
 
     - name: Run security scan with go vet
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.dll
 *.so
 *.dylib
+.bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,12 @@
 .PHONY: fmt
 fmt: ensure-golangci-linter
 	gofmt -s -w .
-	$(GOPATH)/bin/golangci-lint run --fix
+	$(GOLANGCI_LINT_BIN) run --fix
 
 .PHONY: lint
 lint: modules ensure-golangci-linter
 	@echo Linting...
-	$(GOPATH)/bin/golangci-lint run -v ./...
+	$(GOLANGCI_LINT_BIN) run -v ./...
 	@echo Done.
 
 .PHONY: test
@@ -46,9 +46,10 @@ clean:
 	go clean ./...
 	@echo Done.
 
-GOLANGCI_LINT_VERSION := 2.2.0
-GOLANGCI_LINT_BIN := $(GOPATH)/bin/golangci-lint
-GOLANGCI_LINT_INSTALL_COMMAND := GOBIN=$(GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
+GOLANGCI_LINT_VERSION := 2.7.2
+GOLANGCI_LINT_BIN_DIR := ./.bin
+GOLANGCI_LINT_BIN := $(GOLANGCI_LINT_BIN_DIR)/golangci-lint
+GOLANGCI_LINT_INSTALL_COMMAND := curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(GOLANGCI_LINT_BIN_DIR) v$(GOLANGCI_LINT_VERSION)
 
 .PHONY: ensure-golangci-linter
 ensure-golangci-linter:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuclio/opa-client
 
-go 1.23.8
+go 1.25.5
 
 require (
 	github.com/nuclio/errors v0.0.4


### PR DESCRIPTION
- Add read permissions to `ci.yaml`
- Bump github action versions
- Pin third-party action to specific commit (`golangci-lint-action`)
- Bump Go to 1.25.5
- Bump golangci-lint to 2.7.2
- Align golangci-lint installation with [recommended way](https://golangci-lint.run/docs/welcome/install/local/#binaries)

https://iguazio.atlassian.net/browse/NUC-689