### PR TITLE
[Authz] Add QueryAllowedProjects client method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ import (
 
 func main() {
     // Create configuration
-    config := &opa.Config{ 
-        ClientKind:           opa.ClientKindHTTP,
-        Address:              "http://localhost:8181",
-        PermissionQueryPath:  "/v1/data/authz/allow",
-        PermissionFilterPath: "/v1/data/authz/filter_allowed",
-        RequestTimeout:       10,
-        Verbose:              false,
+    config := &opa.Config{
+        ClientKind:               opa.ClientKindHTTP,
+        Address:                  "http://localhost:8181",
+        PermissionQueryPath:      "/v1/data/authz/allow",
+        PermissionFilterPath:     "/v1/data/authz/filter_allowed",
+        AllowedProjectsQueryPath: "/v1/data/authz/allowed_projects",
+        RequestTimeout:           10,
+        Verbose:                  false,
     }
     
     // Create client
@@ -64,6 +65,15 @@ func main() {
             MemberIds: []string{"user123"},
         },
     )
+
+    // Query allowed projects
+    projects, err := client.QueryAllowedProjects(
+        context.Background(),
+        &opa.PermissionOptions{
+            MemberIds: []string{"user123", "group456"},
+        },
+    )
+    // projects may be ["*"] (all projects) or a list of concrete project names
 }
 ```
 
@@ -75,6 +85,7 @@ func main() {
 | `Address` | `string` | OPA server URL | - |
 | `PermissionQueryPath` | `string` | Single permission query endpoint | - |
 | `PermissionFilterPath` | `string` | Multi-resource query endpoint | - |
+| `AllowedProjectsQueryPath` | `string` | Allowed-projects query endpoint | - |
 | `RequestTimeout` | `int` | HTTP timeout in seconds | 10 |
 | `Verbose` | `bool` | Enable verbose logging | `false` |
 | `OverrideHeaderValue` | `string` | Value for bypass functionality | - |

--- a/factory.go
+++ b/factory.go
@@ -32,6 +32,7 @@ func CreateOpaClient(parentLogger logger.Logger, opaConfiguration *Config) Clien
 			opaConfiguration.Address,
 			opaConfiguration.PermissionQueryPath,
 			opaConfiguration.PermissionFilterPath,
+			opaConfiguration.AllowedProjectsQueryPath,
 			time.Duration(opaConfiguration.RequestTimeout)*time.Second,
 			opaConfiguration.Verbose,
 			opaConfiguration.OverrideHeaderValue,

--- a/http.go
+++ b/http.go
@@ -112,7 +112,7 @@ func (c *HTTPClient) QueryPermissionsMultiResources(ctx context.Context,
 
 	var response PermissionFilterResponse
 	if err := c.doRequest(ctx, c.permissionFilterPath, request, &response); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to do query permissions multi resources HTTP request")
 	}
 
 	if c.verbose {
@@ -146,7 +146,7 @@ func (c *HTTPClient) QueryPermissions(ctx context.Context,
 
 	var response PermissionQueryResponse
 	if err := c.doRequest(ctx, c.permissionQueryPath, request, &response); err != nil {
-		return false, err
+		return false, errors.Wrap(err, "Failed to do query permissions HTTP request")
 	}
 
 	if c.verbose {
@@ -174,7 +174,7 @@ func (c *HTTPClient) QueryAllowedProjects(ctx context.Context,
 
 	var response AllowedProjectsResponse
 	if err := c.doRequest(ctx, c.allowedProjectsQueryPath, request, &response); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to do query allowed projects HTTP request")
 	}
 
 	if c.verbose {

--- a/http.go
+++ b/http.go
@@ -30,20 +30,22 @@ import (
 )
 
 type HTTPClient struct {
-	logger               logger.Logger
-	address              string
-	permissionQueryPath  string
-	permissionFilterPath string
-	requestTimeout       time.Duration
-	verbose              bool
-	overrideHeaderValue  string
-	httpClient           *http.Client
+	logger                   logger.Logger
+	address                  string
+	permissionQueryPath      string
+	permissionFilterPath     string
+	allowedProjectsQueryPath string
+	requestTimeout           time.Duration
+	verbose                  bool
+	overrideHeaderValue      string
+	httpClient               *http.Client
 }
 
 func NewHTTPClient(parentLogger logger.Logger,
 	address string,
 	permissionQueryPath string,
 	permissionFilterPath string,
+	allowedProjectsQueryPath string,
 	requestTimeout time.Duration,
 	verbose bool,
 	overrideHeaderValue string,
@@ -66,13 +68,14 @@ func NewHTTPClient(parentLogger logger.Logger,
 	}
 
 	newClient := HTTPClient{
-		logger:               parentLogger.GetChild("opa"),
-		address:              address,
-		permissionQueryPath:  permissionQueryPath,
-		permissionFilterPath: permissionFilterPath,
-		requestTimeout:       requestTimeout,
-		verbose:              verbose,
-		overrideHeaderValue:  overrideHeaderValue,
+		logger:                   parentLogger.GetChild("opa"),
+		address:                  address,
+		permissionQueryPath:      permissionQueryPath,
+		permissionFilterPath:     permissionFilterPath,
+		allowedProjectsQueryPath: allowedProjectsQueryPath,
+		requestTimeout:           requestTimeout,
+		verbose:                  verbose,
+		overrideHeaderValue:      overrideHeaderValue,
 		httpClient: &http.Client{
 			Timeout:   requestTimeout,
 			Transport: transport,
@@ -91,87 +94,34 @@ func (c *HTTPClient) QueryPermissionsMultiResources(ctx context.Context,
 	action Action,
 	permissionOptions *PermissionOptions) ([]bool, error) {
 
-	// initialize results
 	results := make([]bool, len(resources))
 
 	// If the override header value matches the configured override header value, allow without checking
 	if c.overrideHeaderValue != "" && permissionOptions.OverrideHeaderValue == c.overrideHeaderValue {
-
-		// allow them all
 		for i := 0; i < len(results); i++ {
 			results[i] = true
 		}
-
 		return results, nil
 	}
 
-	requestURL := fmt.Sprintf("%s%s", c.address, c.permissionFilterPath)
-
-	// send the request
-	headers := map[string]string{
-		"Content-Type": "application/json",
-		"User-Agent":   UserAgent,
-	}
 	request := PermissionFilterRequest{Input: PermissionFilterRequestInput{
 		resources,
 		string(action),
 		permissionOptions.MemberIds,
 	}}
-	requestBody, err := json.Marshal(request)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to generate request body")
-	}
 
-	if c.verbose {
-		c.logger.InfoWithCtx(ctx,
-			"Sending request to OPA",
-			"requestBody", string(requestBody),
-			"requestURL", requestURL)
-	}
-	var responseBody []byte
-	if err := retryUntilSuccessful(6*time.Second,
-		1*time.Second,
-		func() bool {
-			responseBody, _, err = sendHTTPRequest(ctx,
-				c.httpClient,
-				http.MethodPost,
-				requestURL,
-				requestBody,
-				headers,
-				[]*http.Cookie{},
-				http.StatusOK)
-			if err != nil {
-				c.logger.WarnWithCtx(ctx, "Failed to send HTTP request to OPA, retrying",
-					"err", err.Error())
-				return false
-			}
-			return true
-		}); err != nil {
-		if c.verbose {
-			c.logger.ErrorWithCtx(ctx,
-				"Failed to send HTTP request to OPA",
-				"err", errors.GetErrorStackString(err, 10))
-		}
-		return nil, errors.Wrap(err, "Failed to send HTTP request to OPA")
-	}
-
-	if c.verbose {
-		c.logger.InfoWithCtx(ctx, "Received response from OPA",
-			"responseBody", string(responseBody))
-	}
-
-	permissionFilterResponse := PermissionFilterResponse{}
-	if err := json.Unmarshal(responseBody, &permissionFilterResponse); err != nil {
-		return nil, errors.Wrap(err, "Failed to unmarshal response body")
+	var response PermissionFilterResponse
+	if err := c.doRequest(ctx, c.permissionFilterPath, request, &response); err != nil {
+		return nil, err
 	}
 
 	if c.verbose {
 		c.logger.InfoWithCtx(ctx, "Successfully unmarshalled permission filter response",
-			"permissionFilterResponse", permissionFilterResponse)
+			"permissionFilterResponse", response)
 	}
 
 	for resourceIdx, resource := range resources {
-		if slices.Contains(permissionFilterResponse.Result, resource) {
+		if slices.Contains(response.Result, resource) {
 			results[resourceIdx] = true
 		}
 	}
@@ -188,21 +138,66 @@ func (c *HTTPClient) QueryPermissions(ctx context.Context,
 		return true, nil
 	}
 
-	requestURL := fmt.Sprintf("%s%s", c.address, c.permissionQueryPath)
-
-	// send the request
-	headers := map[string]string{
-		"Content-Type": "application/json",
-		"User-Agent":   UserAgent,
-	}
 	request := PermissionQueryRequest{Input: PermissionQueryRequestInput{
 		resource,
 		string(action),
 		permissionOptions.MemberIds,
 	}}
+
+	var response PermissionQueryResponse
+	if err := c.doRequest(ctx, c.permissionQueryPath, request, &response); err != nil {
+		return false, err
+	}
+
+	if c.verbose {
+		c.logger.InfoWithCtx(ctx, "Successfully unmarshalled permission response",
+			"permissionResponse", response)
+	}
+
+	return response.Result, nil
+}
+
+// QueryAllowedProjects returns the set of project names the caller (identified by
+// permissionOptions.MemberIds) is allowed to read or list. A returned slice containing
+// "*" signals that all projects are accessible.
+func (c *HTTPClient) QueryAllowedProjects(ctx context.Context,
+	permissionOptions *PermissionOptions) ([]string, error) {
+
+	// If the override header value matches the configured override header value, allow all
+	if c.overrideHeaderValue != "" && permissionOptions.OverrideHeaderValue == c.overrideHeaderValue {
+		return []string{"*"}, nil
+	}
+
+	request := AllowedProjectsRequest{Input: AllowedProjectsRequestInput{
+		Ids: permissionOptions.MemberIds,
+	}}
+
+	var response AllowedProjectsResponse
+	if err := c.doRequest(ctx, c.allowedProjectsQueryPath, request, &response); err != nil {
+		return nil, err
+	}
+
+	if c.verbose {
+		c.logger.InfoWithCtx(ctx, "Successfully unmarshalled allowed projects response",
+			"allowedProjectsResponse", response)
+	}
+
+	return response.Result, nil
+}
+
+// doRequest marshals request, POSTs to address+path with retry, and unmarshals
+// the response into respOut. Honors verbose logging.
+func (c *HTTPClient) doRequest(ctx context.Context, path string, request any, respOut any) error {
+	requestURL := fmt.Sprintf("%s%s", c.address, path)
+
+	headers := map[string]string{
+		"Content-Type": "application/json",
+		"User-Agent":   UserAgent,
+	}
+
 	requestBody, err := json.Marshal(request)
 	if err != nil {
-		return false, errors.Wrap(err, "Failed to generate request body")
+		return errors.Wrap(err, "Failed to generate request body")
 	}
 
 	if c.verbose {
@@ -210,6 +205,7 @@ func (c *HTTPClient) QueryPermissions(ctx context.Context,
 			"requestBody", string(requestBody),
 			"requestURL", requestURL)
 	}
+
 	var responseBody []byte
 	if err := retryUntilSuccessful(6*time.Second,
 		1*time.Second,
@@ -233,7 +229,7 @@ func (c *HTTPClient) QueryPermissions(ctx context.Context,
 			c.logger.ErrorWithCtx(ctx, "Failed to send HTTP request to OPA",
 				"err", errors.GetErrorStackString(err, 10))
 		}
-		return false, errors.Wrap(err, "Failed to send HTTP request to OPA")
+		return errors.Wrap(err, "Failed to send HTTP request to OPA")
 	}
 
 	if c.verbose {
@@ -241,15 +237,9 @@ func (c *HTTPClient) QueryPermissions(ctx context.Context,
 			"responseBody", string(responseBody))
 	}
 
-	permissionResponse := PermissionQueryResponse{}
-	if err := json.Unmarshal(responseBody, &permissionResponse); err != nil {
-		return false, errors.Wrap(err, "Failed to unmarshal response body")
+	if err := json.Unmarshal(responseBody, respOut); err != nil {
+		return errors.Wrap(err, "Failed to unmarshal response body")
 	}
 
-	if c.verbose {
-		c.logger.InfoWithCtx(ctx, "Successfully unmarshalled permission response",
-			"permissionResponse", permissionResponse)
-	}
-
-	return permissionResponse.Result, nil
+	return nil
 }

--- a/http_test.go
+++ b/http_test.go
@@ -33,10 +33,11 @@ import (
 
 type HTTPClientTestSuite struct {
 	suite.Suite
-	logger         logger.Logger
-	ctx            context.Context
-	testHTTPServer *httptest.Server
-	httpClient     *HTTPClient
+	logger                      logger.Logger
+	ctx                         context.Context
+	testHTTPServer              *httptest.Server
+	httpClient                  *HTTPClient
+	allowedProjectsRequestCount int
 }
 
 func (suite *HTTPClientTestSuite) SetupTest() {
@@ -45,9 +46,11 @@ func (suite *HTTPClientTestSuite) SetupTest() {
 	suite.Require().NoError(err)
 
 	suite.ctx = context.Background()
+	suite.allowedProjectsRequestCount = 0
 
 	allowPath := "/v1/data/authz/allow"
 	filterPath := "/v1/data/authz/filter_allowed"
+	allowedProjectsPath := "/v1/data/platform/authz/allowed_projects"
 
 	// Create test HTTP server
 	suite.testHTTPServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -86,6 +89,20 @@ func (suite *HTTPClientTestSuite) SetupTest() {
 			w.Header().Set("Content-Type", "application/json")
 			err = json.NewEncoder(w).Encode(permissionResponse)
 			suite.Require().NoError(err)
+
+		case allowedProjectsPath:
+			suite.allowedProjectsRequestCount++
+
+			var allowedProjectsRequest AllowedProjectsRequest
+			err := json.NewDecoder(r.Body).Decode(&allowedProjectsRequest)
+			suite.Require().NoError(err)
+
+			result := computeAllowedProjects(allowedProjectsRequest.Input.Ids)
+
+			response := AllowedProjectsResponse{Result: result}
+			w.Header().Set("Content-Type", "application/json")
+			err = json.NewEncoder(w).Encode(response)
+			suite.Require().NoError(err)
 		}
 	}))
 
@@ -95,6 +112,7 @@ func (suite *HTTPClientTestSuite) SetupTest() {
 		suite.testHTTPServer.URL,
 		allowPath,
 		filterPath,
+		allowedProjectsPath,
 		5*time.Second,
 		true, // Enable verbose logging for tests
 		"test-override-value",
@@ -201,6 +219,98 @@ func (suite *HTTPClientTestSuite) TestQueryPermissionsMultiResources_WithOverrid
 	suite.Require().True(permissions[1])
 	suite.Require().True(permissions[2])
 	suite.Require().True(permissions[3])
+}
+
+func (suite *HTTPClientTestSuite) TestQueryAllowedProjects_Wildcard() {
+	projects, err := suite.httpClient.QueryAllowedProjects(
+		suite.ctx,
+		&PermissionOptions{
+			MemberIds: []string{"admin"},
+		},
+	)
+
+	suite.Require().NoError(err)
+	suite.Require().Equal([]string{"*"}, projects)
+}
+
+func (suite *HTTPClientTestSuite) TestQueryAllowedProjects_ConcreteProjects() {
+	projects, err := suite.httpClient.QueryAllowedProjects(
+		suite.ctx,
+		&PermissionOptions{
+			MemberIds: []string{"read-only-user", "reader-group"},
+		},
+	)
+
+	suite.Require().NoError(err)
+	suite.Require().ElementsMatch([]string{"abc", "def"}, projects)
+}
+
+func (suite *HTTPClientTestSuite) TestQueryAllowedProjects_NoProjects() {
+	projects, err := suite.httpClient.QueryAllowedProjects(
+		suite.ctx,
+		&PermissionOptions{
+			MemberIds: []string{"unknown-user"},
+		},
+	)
+
+	suite.Require().NoError(err)
+	suite.Require().Empty(projects)
+}
+
+func (suite *HTTPClientTestSuite) TestQueryAllowedProjects_WithOverride() {
+	projects, err := suite.httpClient.QueryAllowedProjects(
+		suite.ctx,
+		&PermissionOptions{
+			MemberIds:           []string{"unknown-user"}, // would normally yield empty
+			OverrideHeaderValue: "test-override-value",
+		},
+	)
+
+	suite.Require().NoError(err)
+	suite.Require().Equal([]string{"*"}, projects)
+	suite.Require().Equal(0, suite.allowedProjectsRequestCount,
+		"server must not be hit when override matches")
+}
+
+func (suite *HTTPClientTestSuite) TestQueryAllowedProjects_EmptyIds() {
+	projects, err := suite.httpClient.QueryAllowedProjects(
+		suite.ctx,
+		&PermissionOptions{
+			MemberIds: []string{},
+		},
+	)
+
+	suite.Require().NoError(err)
+	suite.Require().Empty(projects)
+}
+
+// computeAllowedProjects is a test helper that emulates the allowed_projects.rego
+// rule. It returns ["*"] if any id is "admin" or "wildcard-user"; otherwise it
+// returns the union of concrete project names from the fixture map below.
+func computeAllowedProjects(ids []string) []string {
+	for _, id := range ids {
+		if id == "admin" || id == "wildcard-user" {
+			return []string{"*"}
+		}
+	}
+
+	fixture := map[string][]string{
+		"read-only-user": {"abc"},
+		"reader-group":   {"def"},
+	}
+
+	seen := make(map[string]struct{})
+	var result []string
+	for _, id := range ids {
+		for _, name := range fixture[id] {
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			result = append(result, name)
+		}
+	}
+	return result
 }
 
 func TestHTTPClientTestSuite(t *testing.T) {

--- a/mock.go
+++ b/mock.go
@@ -42,3 +42,9 @@ func (mc *MockClient) QueryPermissionsMultiResources(ctx context.Context,
 	args := mc.Called(ctx, resources, action, permissionOptions)
 	return args.Get(0).([]bool), args.Error(1)
 }
+
+func (mc *MockClient) QueryAllowedProjects(ctx context.Context,
+	permissionOptions *PermissionOptions) ([]string, error) {
+	args := mc.Called(ctx, permissionOptions)
+	return args.Get(0).([]string), args.Error(1)
+}

--- a/nop.go
+++ b/nop.go
@@ -60,3 +60,12 @@ func (c *NopClient) QueryPermissions(ctx context.Context, resource string, actio
 	}
 	return true, nil
 }
+
+func (c *NopClient) QueryAllowedProjects(ctx context.Context, permissionOptions *PermissionOptions) ([]string, error) {
+	if c.verbose {
+		c.logger.InfoWithCtx(ctx,
+			"Skipping allowed-projects query",
+			"permissionOptions", permissionOptions)
+	}
+	return []string{"*"}, nil
+}

--- a/opa.go
+++ b/opa.go
@@ -48,4 +48,10 @@ type Client interface {
 	// QueryPermissionsMultiResources queries permissions for multiple resources at once.
 	// Returns a slice of booleans where each index corresponds to the resource at the same index.
 	QueryPermissionsMultiResources(context.Context, []string, Action, *PermissionOptions) ([]bool, error)
+
+	// QueryAllowedProjects returns the set of project names the caller (identified by
+	// PermissionOptions.MemberIds) is allowed to read or list. A returned slice
+	// containing "*" signals that all projects are accessible — callers are responsible
+	// for treating "*" as a wildcard; no concrete names are returned alongside it.
+	QueryAllowedProjects(context.Context, *PermissionOptions) ([]string, error)
 }

--- a/types.go
+++ b/types.go
@@ -46,6 +46,9 @@ type Config struct {
 	// the path used when querying multiple resources against opa server (e.g.: /v1/data/somewhere/authz/filter_allowed)
 	PermissionFilterPath string `json:"permissionFilterPath,omitempty"`
 
+	// the path used when querying allowed projects against opa server (e.g.: /v1/data/platform/authz/allowed_projects)
+	AllowedProjectsQueryPath string `json:"allowedProjectsQueryPath,omitempty"`
+
 	// for extra verbosity
 	Verbose bool `json:"verbose,omitempty"`
 
@@ -88,6 +91,18 @@ type PermissionQueryResponse struct {
 }
 
 type PermissionFilterResponse struct {
+	Result []string `json:"result,omitempty"`
+}
+
+type AllowedProjectsRequestInput struct {
+	Ids []string `json:"ids,omitempty"`
+}
+
+type AllowedProjectsRequest struct {
+	Input AllowedProjectsRequestInput `json:"input,omitempty"`
+}
+
+type AllowedProjectsResponse struct {
 	Result []string `json:"result,omitempty"`
 }
 


### PR DESCRIPTION
### 📝 Description

Adds a third query method, `QueryAllowedProjects`, to the OPA `Client` interface. It calls the new `allowed_projects` Rego rule (orca PR #707) and returns the set of project names the caller is allowed to read or list. A returned slice containing `"*"` signals "all projects accessible" — callers treat `"*"` as a wildcard; no concrete names are returned alongside it.

This gives consumers a single OPA query to compute project-scoped visibility instead of filtering per-resource paths.

---

### 🛠️ Changes Made

- `types.go`: new `Config.AllowedProjectsQueryPath` field; new `AllowedProjectsRequest`/`AllowedProjectsRequestInput`/`AllowedProjectsResponse` types.
- `opa.go`: extend `Client` interface with `QueryAllowedProjects(ctx, *PermissionOptions) ([]string, error)`.
- `http.go`:
  - Extract a private `doRequest` helper that all three query methods share (URL build, headers, marshal, retry loop, verbose request/response logging, unmarshal). Existing `QueryPermissions` and `QueryPermissionsMultiResources` are refactored onto it; observable behavior (retry timing, log keys, error wrapping) is unchanged.
  - Add `QueryAllowedProjects`. Override-header bypass returns `["*"]`, consistent with the other methods' bypass semantics.
  - `NewHTTPClient` gains an `allowedProjectsQueryPath` parameter.
- `nop.go`: implement the new method, returning `["*"]` (fail-open, consistent with the other Nop methods).
- `mock.go`: testify passthrough.
- `factory.go`: thread `Config.AllowedProjectsQueryPath` into `NewHTTPClient`.
- `README.md`: document the new method and config field.

---

### ✅ Checklist

- [x] I updated the documentation (if applicable) — `README.md`
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Unit tests in `http_test.go` (build tag `test_unit`). The existing in-test OPA `httptest.Server` gains a third route at `/v1/data/platform/authz/allowed_projects` plus a fixture-backed test helper that emulates the rego rule.

Five new cases:

- `TestQueryAllowedProjects_Wildcard` — admin id → `["*"]`.
- `TestQueryAllowedProjects_ConcreteProjects` — two ids' concrete names unioned (`{"abc","def"}`, asserted with `ElementsMatch` since the rego returns a set).
- `TestQueryAllowedProjects_NoProjects` — unknown id → empty.
- `TestQueryAllowedProjects_WithOverride` — override header → `["*"]`, server not hit (asserted via a request-count counter).
- `TestQueryAllowedProjects_EmptyIds` — empty `MemberIds` → empty.

Verification:

- `make test` — 10/10 pass (5 new + 5 existing).
- `make lint` — `0 issues`.
- `go vet ./...` — clean.

---

### 🔗 References

- Ticket link: IG4-2244
- Design docs links: n/a
- External links: orca PR [#707](https://github.com/iguazio/orca/pull/707) — adds the `allowed_projects` Rego rule this method consumes.

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

`NewHTTPClient` gains a new `allowedProjectsQueryPath` parameter (positioned between `permissionFilterPath` and `requestTimeout`). Direct callers of `NewHTTPClient` must add the new argument.

The `Client` interface also grows a method (`QueryAllowedProjects`) — any custom implementations of `Client` outside this repo must add it.

Callers using only the documented `CreateOpaClient(logger, *Config)` entry point are unaffected at the call site, but should set `Config.AllowedProjectsQueryPath` before invoking the new method.

---

### 🔍️ Additional Notes

The `doRequest` extraction is a refactor of pre-existing duplication, not a behavior change. Reviewers may want to spot-check that retry timing (`6s` total, `1s` interval), verbose log keys (`requestBody`, `requestURL`, `responseBody`), and error wrapping (`"Failed to send HTTP request to OPA"`) are preserved exactly across the two existing methods.

`PermissionOptions.RaiseForbidden` and `SkipLoggingForbidden` are accepted on the new method for API consistency but, as in the existing methods, are passthrough fields not acted on inside the client.